### PR TITLE
1-2-3-5-6-7-8 [fix, feat, docs, 7-refactor] 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-
+.properties
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     //redis를 사용하기 위한 의존성
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.1'
+    implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
+
     //mysql전 h2콘솔을 사용하기위해서 사용
     runtimeOnly 'com.h2database:h2'
     //이메일 인증
@@ -49,6 +50,7 @@ dependencies {
 
     //websocket사용을 위한 의존성
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team/final8teamproject/base/entity/BaseEntity.java
+++ b/src/main/java/com/team/final8teamproject/base/entity/BaseEntity.java
@@ -1,0 +1,49 @@
+package com.team.final8teamproject.base.entity;
+
+import com.team.final8teamproject.user.entity.Timestamped;
+import com.team.final8teamproject.user.entity.UserRoleEnum;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+public class BaseEntity extends Timestamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "User_ID")
+    private Long id;
+    @Column(nullable = false, unique = true)
+    private String username;
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private UserRoleEnum role;
+    public BaseEntity(String username, String password, String email, UserRoleEnum role){
+        this.username = username;
+        this.password = password;
+        this.email=email;
+        this.role = role;
+    }
+
+    public void changePassword(String password){
+        this.password = password;
+    }
+
+    public boolean isUserId(Long userid) {
+        return this.id.equals(userid);
+    }
+
+    public String getWriterName() {
+        return this.username;
+    }
+}

--- a/src/main/java/com/team/final8teamproject/base/entity/BaseEntity.java
+++ b/src/main/java/com/team/final8teamproject/base/entity/BaseEntity.java
@@ -1,11 +1,13 @@
 package com.team.final8teamproject.base.entity;
 
+import com.team.final8teamproject.manager.entity.ManagerRoleEnum;
 import com.team.final8teamproject.user.entity.Timestamped;
 import com.team.final8teamproject.user.entity.UserRoleEnum;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.minidev.json.annotate.JsonIgnore;
 
 @Entity
 @Getter
@@ -19,15 +21,15 @@ public class BaseEntity extends Timestamped {
     private Long id;
     @Column(nullable = false, unique = true)
     private String username;
+    @JsonIgnore
     @Column(nullable = false)
     private String password;
-
     @Column(nullable = false)
     private String email;
-
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
+
     public BaseEntity(String username, String password, String email, UserRoleEnum role){
         this.username = username;
         this.password = password;
@@ -35,6 +37,11 @@ public class BaseEntity extends Timestamped {
         this.role = role;
     }
 
+    public BaseEntity(String username, String password, UserRoleEnum role){
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
     public void changePassword(String password){
         this.password = password;
     }
@@ -45,5 +52,9 @@ public class BaseEntity extends Timestamped {
 
     public String getWriterName() {
         return this.username;
+    }
+
+    public void approvalManager(UserRoleEnum role) {
+        this.role = role;
     }
 }

--- a/src/main/java/com/team/final8teamproject/base/repository/BaseRepository.java
+++ b/src/main/java/com/team/final8teamproject/base/repository/BaseRepository.java
@@ -1,0 +1,12 @@
+package com.team.final8teamproject.base.repository;
+
+import com.team.final8teamproject.base.entity.BaseEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BaseRepository extends JpaRepository<BaseEntity, Long> {
+
+    Optional<BaseEntity> findByUsername(String username);
+    Optional<BaseEntity> findByEmail(String email);
+}

--- a/src/main/java/com/team/final8teamproject/board/comment/commentReply/controller/T_exerciseCommentReplyController.java
+++ b/src/main/java/com/team/final8teamproject/board/comment/commentReply/controller/T_exerciseCommentReplyController.java
@@ -3,6 +3,7 @@ package com.team.final8teamproject.board.comment.commentReply.controller;
 import com.team.final8teamproject.board.comment.commentReply.dto.CreatT_exerciseCommentReplyRequestDTO;
 import com.team.final8teamproject.board.comment.commentReply.service.T_exerciseCommentReplyService;
 import com.team.final8teamproject.security.userservice.UserDetailsImpl;
+import com.team.final8teamproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,7 +20,7 @@ public class T_exerciseCommentReplyController {
     public ResponseEntity<String> creatCommentReply(@PathVariable Long commentId,
                                                     @AuthenticationPrincipal UserDetailsImpl userDetails,
                                                     @RequestBody CreatT_exerciseCommentReplyRequestDTO requestDTO){
-        String username = userDetails.getUser().getUsername();
+        String username = userDetails.getBase().getUsername();
         String comment = requestDTO.getComment();
         return t_exerciseCommentReplyService.creatCommentRely(commentId,comment,username);
     }
@@ -29,13 +30,13 @@ public class T_exerciseCommentReplyController {
     public ResponseEntity<String> updateCommentReply(@RequestBody CreatT_exerciseCommentReplyRequestDTO requestDTO,
                                                      @AuthenticationPrincipal UserDetailsImpl userDetails,
                                                      @PathVariable Long commentId){
-        return t_exerciseCommentReplyService.updateCommentReply(requestDTO,userDetails.getUser(),commentId);
+        return t_exerciseCommentReplyService.updateCommentReply(requestDTO, userDetails.getBase().getUsername(),commentId);
     }
 
     //대댓글 삭제
     @DeleteMapping("/comment/{commentId}")
     public ResponseEntity<String> deleteCommentReply(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                      @PathVariable Long commentId) {
-        return t_exerciseCommentReplyService.deleteCommentReply(userDetails.getUser(),commentId);
+        return t_exerciseCommentReplyService.deleteCommentReply(userDetails.getBase().getUsername(),commentId);
     }
 }

--- a/src/main/java/com/team/final8teamproject/board/comment/commentReply/service/T_exerciseCommentReplyService.java
+++ b/src/main/java/com/team/final8teamproject/board/comment/commentReply/service/T_exerciseCommentReplyService.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface T_exerciseCommentReplyService {
     ResponseEntity<String> creatCommentRely(Long commentId, String comment, String username);
 
-    ResponseEntity<String> updateCommentReply(CreatT_exerciseCommentReplyRequestDTO requestDTO, User user, Long commentID);
+    ResponseEntity<String> updateCommentReply(CreatT_exerciseCommentReplyRequestDTO requestDTO, String username, Long commentID);
 
-    ResponseEntity<String> deleteCommentReply(User user, Long commentId);
+    ResponseEntity<String> deleteCommentReply(String username, Long commentId);
 }

--- a/src/main/java/com/team/final8teamproject/board/comment/commentReply/service/T_exerciseCommentReplyServiceImpl.java
+++ b/src/main/java/com/team/final8teamproject/board/comment/commentReply/service/T_exerciseCommentReplyServiceImpl.java
@@ -7,7 +7,6 @@ import com.team.final8teamproject.board.comment.entity.T_exerciseComment;
 import com.team.final8teamproject.board.comment.repository.T_exerciseCommentRepository;
 import com.team.final8teamproject.share.exception.CustomException;
 import com.team.final8teamproject.share.exception.ExceptionStatus;
-import com.team.final8teamproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,8 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class T_exerciseCommentReplyServiceImple implements T_exerciseCommentReplyService {
-
+public class T_exerciseCommentReplyServiceImpl implements T_exerciseCommentReplyService {
     private final T_exerciseCommentRepository tExerciseCommentRepository;
 
     private final T_exerciseCommentReplyRepository tExerciseCommentReplyRepository;
@@ -38,9 +36,8 @@ public class T_exerciseCommentReplyServiceImple implements T_exerciseCommentRepl
 
     @Override
     @Transactional
-    public ResponseEntity<String> updateCommentReply(CreatT_exerciseCommentReplyRequestDTO requestDTO, User user, Long commentID) {
+    public ResponseEntity<String> updateCommentReply(CreatT_exerciseCommentReplyRequestDTO requestDTO, String username, Long commentID) {
         T_exerciseCommentReply commentReply = tExerciseCommentReplyRepository.findById(commentID).orElseThrow(() -> new CustomException(ExceptionStatus.COMMENT_REPLY_NOT_EXIST));
-        String username = user.getUsername();
         String comment = requestDTO.getComment();
         if (commentReply.isWriter(username)) {
            commentReply.update(comment);
@@ -51,12 +48,10 @@ public class T_exerciseCommentReplyServiceImple implements T_exerciseCommentRepl
 
     @Override
     @Transactional
-    public ResponseEntity<String> deleteCommentReply(User user, Long commentId) {
-        String username = user.getUsername();
+    public ResponseEntity<String> deleteCommentReply(String username, Long commentId) {
         T_exerciseCommentReply commentReply = tExerciseCommentReplyRepository.findById(commentId).orElseThrow(() -> new CustomException(ExceptionStatus.COMMENT_REPLY_NOT_EXIST));
         if(commentReply.isWriter(username)){
             tExerciseCommentReplyRepository.deleteById(commentId);
-
             return new ResponseEntity<>("대댓글 삭제완료",HttpStatus.OK);
         }
         throw new CustomException(ExceptionStatus.WRONG_USER_T0_COMMENT_REPLY);

--- a/src/main/java/com/team/final8teamproject/board/comment/controller/T_exerciseCommentController.java
+++ b/src/main/java/com/team/final8teamproject/board/comment/controller/T_exerciseCommentController.java
@@ -3,6 +3,7 @@ package com.team.final8teamproject.board.comment.controller;
 import com.team.final8teamproject.board.comment.dto.CreatT_exerciseCommentRequestDTO;
 import com.team.final8teamproject.board.comment.service.T_exerciseCommentService;
 import com.team.final8teamproject.security.userservice.UserDetailsImpl;
+import com.team.final8teamproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,20 +19,20 @@ public class T_exerciseCommentController {
     @PostMapping("/{boardId}/comment")
     public ResponseEntity<String> createComment(@RequestBody CreatT_exerciseCommentRequestDTO requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long boardId) {
         String comment = requestDto.getComment();
-        String userName = userDetails.getUser().getUsername();
+        String userName = userDetails.getBase().getUsername();
         return tExerciseCommentService.createComment(comment, boardId,userName);
     }
 
     //댓글삭제
     @DeleteMapping("/{boardId}/comment/{commentId}")
     public ResponseEntity<String> deleteComment(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long commentId) {
-        return tExerciseCommentService.deleteComment(userDetails.getUser(), commentId);
+        return tExerciseCommentService.deleteComment((User) userDetails.getBase(), commentId);
     }
 
     //댓글수정
     @PutMapping("/{boardId}/comment/{commentId}")
     public ResponseEntity<String> updateComment(@RequestBody CreatT_exerciseCommentRequestDTO requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long commentId) {
 
-        return tExerciseCommentService.updateComment(requestDto, userDetails.getUser(), commentId);
+        return tExerciseCommentService.updateComment(requestDto, (User) userDetails.getBase(), commentId);
     }
 }

--- a/src/main/java/com/team/final8teamproject/board/controller/T_exerciseController.java
+++ b/src/main/java/com/team/final8teamproject/board/controller/T_exerciseController.java
@@ -33,7 +33,7 @@ public class T_exerciseController {
 
         String content = creatTExerciseBordRequestDTO.getContent();
         String title = creatTExerciseBordRequestDTO.getTitle();
-        User user = userDetails.getUser();
+        User user = (User) userDetails.getBase();
 
         return t_exerciseService.creatTExerciseBord(title,content,file,user);
     }
@@ -61,7 +61,7 @@ public class T_exerciseController {
     //오운완 게시물 삭제
     @DeleteMapping("/{boardId}")
     public ResponseEntity<String> deleteT_exerciseBoard(@PathVariable Long boardId,@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return t_exerciseService.deleteSalePost(boardId,userDetails.getUser()); //인증은 앞단에서..했다고 가정하니까....
+        return t_exerciseService.deleteSalePost(boardId,(User)userDetails.getBase()); //인증은 앞단에서..했다고 가정하니까....
     }
 
 
@@ -72,7 +72,7 @@ public class T_exerciseController {
                                                       @RequestPart("file") MultipartFile file,
                                                       @AuthenticationPrincipal UserDetailsImpl userDetails)throws IOException{
 
-        User user = userDetails.getUser();
+        User user = (User)userDetails.getBase();
 
         return t_exerciseService.editSalePost(boardId,creatTExerciseBordRequestDTO,user,file);
     }

--- a/src/main/java/com/team/final8teamproject/board/like/controller/T_exerciseLikeController.java
+++ b/src/main/java/com/team/final8teamproject/board/like/controller/T_exerciseLikeController.java
@@ -1,7 +1,9 @@
 package com.team.final8teamproject.board.like.controller;
 
+
 import com.team.final8teamproject.board.like.service.T_exerciseLikeService;
 import com.team.final8teamproject.security.userservice.UserDetailsImpl;
+import com.team.final8teamproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +22,6 @@ public class T_exerciseLikeController {
     @PostMapping("/{boardId}/like")
     public ResponseEntity<String> likeBoard(@PathVariable Long boardId, @AuthenticationPrincipal UserDetailsImpl userDetails ){
 
-            return tExerciseLikeService.likeBoard(userDetails.getUser(),boardId);
+            return tExerciseLikeService.likeBoard((User)userDetails.getBase(),boardId);
     }
 }

--- a/src/main/java/com/team/final8teamproject/board/service/T_exerciseServiceImple.java
+++ b/src/main/java/com/team/final8teamproject/board/service/T_exerciseServiceImple.java
@@ -11,7 +11,6 @@ import com.team.final8teamproject.board.like.service.T_exerciseLikeService;
 import com.team.final8teamproject.board.repository.T_exerciseRepository;
 import com.team.final8teamproject.board.comment.dto.CommentResponseDTO;
 import com.team.final8teamproject.board.comment.entity.T_exerciseComment;
-import com.team.final8teamproject.board.comment.repository.T_exerciseCommentRepository;
 import com.team.final8teamproject.share.exception.CustomException;
 import com.team.final8teamproject.share.exception.ExceptionStatus;
 import com.team.final8teamproject.user.entity.User;
@@ -52,7 +51,7 @@ public class T_exerciseServiceImple  implements  T_exerciseService{
     @Override
     public ResponseEntity<String> creatTExerciseBord(String title, String content, MultipartFile file, User user) throws NullPointerException, IOException {
         UUID uuid = UUID.randomUUID();
-        String filename = uuid+"_"+file.getOriginalFilename();
+        String filename = uuid+"_"+file.getOriginalFilename()+".jpeg";
         String filepath = System.getProperty("user.dir")+"/src/main/resources/static/files";
         File savefile = new File(filepath, filename);
         file.transferTo(savefile);

--- a/src/main/java/com/team/final8teamproject/contact/controller/FaqController.java
+++ b/src/main/java/com/team/final8teamproject/contact/controller/FaqController.java
@@ -32,7 +32,7 @@ public class FaqController {// todo  메서드 마다 권한 설정
   @PostMapping("")
   public ResponseEntity saveFaq(@RequestBody FaqRequest faqRequest,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
-    faqServiceImpl.saveFaq(faqRequest, userDetails.getUser().getId());
+    faqServiceImpl.saveFaq(faqRequest, userDetails.getBase().getId());
     return ResponseEntity.ok("등록 완료");
   }
 
@@ -66,14 +66,14 @@ public class FaqController {// todo  메서드 마다 권한 설정
   public ResponseEntity updateFaq(@PathVariable Long id,
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @RequestBody UpdateFaqRequest updateFaqRequest){
-    faqServiceImpl.updateFaq(id,userDetails.getUser().getId(),updateFaqRequest);
+    faqServiceImpl.updateFaq(id,userDetails.getBase().getId(),updateFaqRequest);
     return ResponseEntity.ok("수정 완료");
   }
   //todo 권한 :관리자
   @DeleteMapping("/{id}")
   public ResponseEntity deleteFaq(@PathVariable Long id,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
-    faqServiceImpl.deleteFaq(id, userDetails.getUser().getId());
+    faqServiceImpl.deleteFaq(id, userDetails.getBase().getId());
     return ResponseEntity.ok("삭제 완료");
   }
 

--- a/src/main/java/com/team/final8teamproject/contact/controller/InquiryController.java
+++ b/src/main/java/com/team/final8teamproject/contact/controller/InquiryController.java
@@ -31,7 +31,7 @@ public class InquiryController {// todo  메서드 마다 권한 설정
   @PostMapping("/user/contact/inquiry")
   public ResponseEntity createInquiry(@RequestBody InquiryRequest inquiryRequest,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
-    inquiryServiceImpl.createInquiry(inquiryRequest, userDetails.getUser().getUsername());
+    inquiryServiceImpl.createInquiry(inquiryRequest, userDetails.getBase().getUsername());
     return ResponseEntity.ok("등록 완료");
   }
 
@@ -67,14 +67,14 @@ public class InquiryController {// todo  메서드 마다 권한 설정
   public ResponseEntity updateInquiry(@PathVariable Long id,
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @RequestBody InquiryRequest inquiryRequest){
-    inquiryServiceImpl.updateInquiry(id,userDetails.getUser().getUsername(),inquiryRequest);
+    inquiryServiceImpl.updateInquiry(id,userDetails.getBase().getUsername(),inquiryRequest);
     return ResponseEntity.ok("수정 완료");
   }
   //todo 관리자가 유저 문의글 삭제 가능
   @DeleteMapping("/user/contact/inquiry/{id}")
   public ResponseEntity deleteInquiry(@PathVariable Long id,
       @AuthenticationPrincipal UserDetailsImpl userDetails){
-    inquiryServiceImpl.deleteInquiry(id,userDetails.getUser().getUsername());
+    inquiryServiceImpl.deleteInquiry(id,userDetails.getBase().getUsername());
     return ResponseEntity.ok("삭제 완료");
   }
   //todo 권한 : 관리자만

--- a/src/main/java/com/team/final8teamproject/contact/controller/NoticeController.java
+++ b/src/main/java/com/team/final8teamproject/contact/controller/NoticeController.java
@@ -35,7 +35,7 @@ public class NoticeController {
   @PostMapping("")
   public ResponseEntity saveNotice(@RequestBody NoticeRequest noticeRequest,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
-    noticeServiceImpl.saveNotice(noticeRequest, userDetails.getUser().getId());
+    noticeServiceImpl.saveNotice(noticeRequest, userDetails.getBase().getId());
     return ResponseEntity.ok("등록 완료");
     //new ResponseEntity<>("등록완료",HttpStatus.CREATED);
   }
@@ -71,7 +71,7 @@ public class NoticeController {
   public ResponseEntity updateNotice(@PathVariable Long id,
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @RequestBody UpdateNoticeRequest updateNoticeRequest) {
-    noticeServiceImpl.updateNotice(id, userDetails.getUser().getId(),updateNoticeRequest);
+    noticeServiceImpl.updateNotice(id, userDetails.getBase().getId(),updateNoticeRequest);
     return ResponseEntity.ok("수정 완료");
   }
 
@@ -80,7 +80,7 @@ public class NoticeController {
   @DeleteMapping("/{id}")
   public ResponseEntity deleteNotice(@PathVariable Long id,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
-    noticeServiceImpl.deleteNotice(id, userDetails.getUser().getId());
+    noticeServiceImpl.deleteNotice(id, userDetails.getBase().getId());
     return ResponseEntity.ok("삭제 완료");
 
   }

--- a/src/main/java/com/team/final8teamproject/exception/Exception.java
+++ b/src/main/java/com/team/final8teamproject/exception/Exception.java
@@ -1,6 +1,0 @@
-package com.team.final8teamproject.exception;
-
-
-public class Exception {
-
-}

--- a/src/main/java/com/team/final8teamproject/manager/controller/GeneralManagerController.java
+++ b/src/main/java/com/team/final8teamproject/manager/controller/GeneralManagerController.java
@@ -1,13 +1,14 @@
 package com.team.final8teamproject.manager.controller;
 
-import com.team.final8teamproject.manager.dto.ApprovalRequestDto;
-import com.team.final8teamproject.manager.dto.ManagerMessageDto;
-import com.team.final8teamproject.manager.dto.WaitMangerResponseDto;
+import com.team.final8teamproject.manager.dto.*;
 import com.team.final8teamproject.manager.entity.GeneralManager;
 import com.team.final8teamproject.manager.service.GeneralManagerService;
 import com.team.final8teamproject.security.jwt.JwtUtil;
 import com.team.final8teamproject.security.userservice.UserDetailsImpl;
+import com.team.final8teamproject.user.dto.LoginRequestDto;
+import com.team.final8teamproject.user.dto.LoginResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -21,11 +22,23 @@ import java.util.*;
 public class GeneralManagerController {
     private final GeneralManagerService generalManagerService;
     private final JwtUtil jwtUtil;
-    //저장
+    //저장 (회원가입)
     @PostMapping("/signup")
     public ManagerMessageDto save(GeneralManager manager){
         generalManagerService.save(manager);
         return new ManagerMessageDto("총 관리자 생성에 성공하였습니다.");
+    }
+
+    //총관리자 로그인
+    @PostMapping("/login")
+    public ManagerMessageDto login(@RequestBody ManagerLoginRequestDto loginRequestDto, HttpServletResponse response) {
+        //이름과 유저인지 관리자인지 구분한 토큰을 가져오는 부분
+        LoginResponseDto msg = generalManagerService.login(loginRequestDto);
+        //문자열 token에 가져온 정보를 넣어주는 부분
+        String token = msg.getAccessToken();
+        //헤더를 통해 토큰을 발급해 주는 부분
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+        return new ManagerMessageDto("로그인 되었습니다.");
     }
 
     //승인
@@ -34,7 +47,6 @@ public class GeneralManagerController {
         return generalManagerService.approval(request.getManager());
     }
 //    @AuthenticationPrincipal UserDetailsImpl userDetails
-
     //승인대기 관리자 조회
     @GetMapping("/wait_approval")
     public List<WaitMangerResponseDto> waitManagerList(@PageableDefault Pageable pageable){
@@ -48,4 +60,5 @@ public class GeneralManagerController {
         generalManagerService.logout(accessToken, userDetails.getUsername());
         return new ManagerMessageDto("로그아웃 하셨습니다.");
     }
+
 }

--- a/src/main/java/com/team/final8teamproject/manager/controller/ManagerController.java
+++ b/src/main/java/com/team/final8teamproject/manager/controller/ManagerController.java
@@ -1,12 +1,13 @@
 package com.team.final8teamproject.manager.controller;
 
-import com.team.final8teamproject.manager.dto.ManagerLoginRequestDto;
-import com.team.final8teamproject.manager.dto.ManagerLoginResponseDto;
-import com.team.final8teamproject.manager.dto.ManagerSignupRequestDto;
-import com.team.final8teamproject.manager.dto.ManagerSignupResponseDto;
+import com.team.final8teamproject.manager.dto.*;
 import com.team.final8teamproject.manager.service.ManagerService;
+import com.team.final8teamproject.security.jwt.JwtUtil;
+import com.team.final8teamproject.user.dto.LoginResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,7 +24,12 @@ public class ManagerController {
     }
 
     @PostMapping("/login")
-    public ManagerLoginResponseDto login(ManagerLoginRequestDto requestDto){
-        return managerService.login(requestDto);
+    public ManagerMessageDto login(@RequestBody ManagerLoginRequestDto requestDto, HttpServletResponse response){
+        LoginResponseDto msg = managerService.login(requestDto);
+        //문자열 token에 가져온 정보를 넣어주는 부분
+        String token = msg.getAccessToken();
+        //헤더를 통해 토큰을 발급해 주는 부분
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+        return new ManagerMessageDto("로그인 되었습니다.");
     }
 }

--- a/src/main/java/com/team/final8teamproject/manager/dto/ManagerLoginRequestDto.java
+++ b/src/main/java/com/team/final8teamproject/manager/dto/ManagerLoginRequestDto.java
@@ -1,7 +1,14 @@
 package com.team.final8teamproject.manager.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 public class ManagerLoginRequestDto {
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
 }

--- a/src/main/java/com/team/final8teamproject/manager/dto/ManagerLoginResponseDto.java
+++ b/src/main/java/com/team/final8teamproject/manager/dto/ManagerLoginResponseDto.java
@@ -1,12 +1,23 @@
 package com.team.final8teamproject.manager.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class ManagerLoginResponseDto {
-    private String message;
+//    private String message;
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long refreshTokenExpirationTime;
 
-    public ManagerLoginResponseDto(String message){
-        this.message = message;
+
+    @Builder
+    public ManagerLoginResponseDto(String message,String grantType, String accessToken, String refreshToken, Long refreshTokenExpirationTime) {
+        this.grantType = grantType;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+//        this.message = message;
     }
 }

--- a/src/main/java/com/team/final8teamproject/manager/dto/WaitMangerResponseDto.java
+++ b/src/main/java/com/team/final8teamproject/manager/dto/WaitMangerResponseDto.java
@@ -9,7 +9,7 @@ public class WaitMangerResponseDto {
     private String password;
     private String nickname;
     public WaitMangerResponseDto(Manager manager){
-        this.manager = manager.getManager();
+        this.manager = manager.getManagerName();
         this.password = manager.getPassword();
         this.nickname = manager.getNickname();
     }

--- a/src/main/java/com/team/final8teamproject/manager/entity/Manager.java
+++ b/src/main/java/com/team/final8teamproject/manager/entity/Manager.java
@@ -2,18 +2,21 @@ package com.team.final8teamproject.manager.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import net.minidev.json.annotate.JsonIgnore;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Manager {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @NotBlank
-    private String manager;
+    private String managerName;
     @JsonIgnore
     @NotBlank
     private String password;
@@ -23,8 +26,8 @@ public class Manager {
     private ManagerRoleEnum role;
 
     @Builder
-    public Manager(String manager, String password, String nickname, ManagerRoleEnum role) {
-        this.manager = manager;
+    public Manager(String managerName, String password, String nickname, ManagerRoleEnum role) {
+        this.managerName = managerName;
         this.password = password;
         this.nickname = nickname;
         this.role = role;

--- a/src/main/java/com/team/final8teamproject/manager/entity/Manager.java
+++ b/src/main/java/com/team/final8teamproject/manager/entity/Manager.java
@@ -1,39 +1,28 @@
 package com.team.final8teamproject.manager.entity;
 
+import com.team.final8teamproject.base.entity.BaseEntity;
+import com.team.final8teamproject.user.entity.UserRoleEnum;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import net.minidev.json.annotate.JsonIgnore;
-
-@Entity
+//lombok
+@Entity(name = "Manager")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Manager {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    @NotBlank
-    private String managerName;
-    @JsonIgnore
-    @NotBlank
-    private String password;
+
+@DiscriminatorValue(value = "Manager")
+public class Manager extends BaseEntity{
     private String profileImage;
     @NotBlank
     private String nickname;
-    private ManagerRoleEnum role;
 
     @Builder
-    public Manager(String managerName, String password, String nickname, ManagerRoleEnum role) {
-        this.managerName = managerName;
-        this.password = password;
+    public Manager(String username, String password, String nickname, UserRoleEnum role) {
+        super(username, password, role);
         this.nickname = nickname;
-        this.role = role;
     }
 
-    public void approvalManager(ManagerRoleEnum role) {
-        this.role = role;
-    }
 }

--- a/src/main/java/com/team/final8teamproject/manager/entity/ManagerRepository.java
+++ b/src/main/java/com/team/final8teamproject/manager/entity/ManagerRepository.java
@@ -1,7 +1,0 @@
-package com.team.final8teamproject.manager.entity;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ManagerRepository extends JpaRepository<Manager, Long> {
-
-}

--- a/src/main/java/com/team/final8teamproject/manager/repository/ManagerRepository.java
+++ b/src/main/java/com/team/final8teamproject/manager/repository/ManagerRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface ManagerRepository extends JpaRepository<Manager, Long> {
 
-    Optional<Manager> findByManager(String manager);
-    void deleteByManager(String manager);
+    Optional<Manager> findByManagerName(String manager);
+    void deleteByManagerName(String manager);
     Page<Manager> findByRole(Pageable pageable, ManagerRoleEnum role);
 }

--- a/src/main/java/com/team/final8teamproject/manager/service/GeneralManagerService.java
+++ b/src/main/java/com/team/final8teamproject/manager/service/GeneralManagerService.java
@@ -1,16 +1,15 @@
 package com.team.final8teamproject.manager.service;
 
-import com.team.final8teamproject.manager.dto.ApprovalRequestDto;
-import com.team.final8teamproject.manager.dto.ManagerMessageDto;
-import com.team.final8teamproject.manager.dto.WaitMangerResponseDto;
+import com.team.final8teamproject.manager.dto.*;
 import com.team.final8teamproject.manager.entity.GeneralManager;
+import com.team.final8teamproject.user.dto.LoginResponseDto;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface GeneralManagerService {
     void save(GeneralManager generalManager);
-    ManagerMessageDto login(String manager);
+    LoginResponseDto login(ManagerLoginRequestDto requestDto);
     ManagerMessageDto approval(String manager);
     public List<WaitMangerResponseDto> waitManagerList(Pageable pageable);
     void logout(String accessToken, String username);

--- a/src/main/java/com/team/final8teamproject/manager/service/ManagerService.java
+++ b/src/main/java/com/team/final8teamproject/manager/service/ManagerService.java
@@ -4,10 +4,11 @@ import com.team.final8teamproject.manager.dto.ManagerLoginRequestDto;
 import com.team.final8teamproject.manager.dto.ManagerLoginResponseDto;
 import com.team.final8teamproject.manager.dto.ManagerSignupRequestDto;
 import com.team.final8teamproject.manager.dto.ManagerSignupResponseDto;
+import com.team.final8teamproject.user.dto.LoginResponseDto;
 
 public interface ManagerService {
     ManagerSignupResponseDto signup(ManagerSignupRequestDto managerSignupRequestDto);
-    ManagerLoginResponseDto login(ManagerLoginRequestDto managerLoginRequestDto);
+    LoginResponseDto login(ManagerLoginRequestDto managerLoginRequestDto);
     void logout(String accessToken, String manager);
 
 }

--- a/src/main/java/com/team/final8teamproject/owner/controller/OwnerController.java
+++ b/src/main/java/com/team/final8teamproject/owner/controller/OwnerController.java
@@ -1,0 +1,4 @@
+package com.team.final8teamproject.owner.controller;
+
+public class OwnerController {
+}

--- a/src/main/java/com/team/final8teamproject/owner/entity/Owner.java
+++ b/src/main/java/com/team/final8teamproject/owner/entity/Owner.java
@@ -1,4 +1,49 @@
 package com.team.final8teamproject.owner.entity;
 
-public class Owner {
+import com.team.final8teamproject.base.entity.BaseEntity;
+import com.team.final8teamproject.user.dto.ProfileModifyRequestDto;
+import com.team.final8teamproject.user.entity.User;
+import com.team.final8teamproject.user.entity.UserRoleEnum;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "owner")
+@DiscriminatorValue(value = "Owner")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Owner extends BaseEntity {
+
+    private String profileImage;
+
+
+    @Column(nullable = false)
+    private String ownerNumber;
+
+    @Column(nullable = false)
+    private String nickName;
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private Long experience;
+
+    //오너생성
+    @Builder
+    public Owner(String username, String password, UserRoleEnum role,
+                String nickName, String phoneNumber, String email,
+                Long experience){
+        super(username, password, email, role);
+        this.nickName = nickName;
+        this.phoneNumber = phoneNumber;
+        this.experience = experience;
+    }
+
+    //프로필이미지 수정
+    public void changeOwnerProfile(ProfileModifyRequestDto profileModifyRequestDto) {
+        this.nickName = profileModifyRequestDto.getNickname();
+        this.profileImage = profileModifyRequestDto.getImage();
+        this.phoneNumber = profileModifyRequestDto.getPhoneNumber();
+    }
+
 }

--- a/src/main/java/com/team/final8teamproject/owner/repository/OwnerRepository.java
+++ b/src/main/java/com/team/final8teamproject/owner/repository/OwnerRepository.java
@@ -1,0 +1,7 @@
+package com.team.final8teamproject.owner.repository;
+
+import com.team.final8teamproject.owner.entity.Owner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OwnerRepository extends JpaRepository<Owner, Long> {
+}

--- a/src/main/java/com/team/final8teamproject/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/team/final8teamproject/security/config/WebSecurityConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -19,13 +20,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity // 스프링 Security 지원을 가능하게 함
 //@EnableGlobalMethodSecurity(prePostEnabled = true) // @Secured 어노테이션 활성화
 @EnableScheduling // @Scheduled 어노테이션 활성화
-public class WebSecurityConfig {
+public class WebSecurityConfig implements WebMvcConfigurer {
 
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
@@ -51,6 +53,7 @@ public class WebSecurityConfig {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 //        http.authorizeRequests()
         http.authorizeHttpRequests()//요청에 대한 권한을 지정할 수 있다.
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/api/manager/**").hasAnyRole("Manager","GeneralManager")
                 .requestMatchers("/owner/**").hasAnyRole("Owner","Manager","GeneralManager")
                 .requestMatchers("/api/general/**").hasRole("GeneralManager")
@@ -59,6 +62,7 @@ public class WebSecurityConfig {
                 .requestMatchers("/h2-console").permitAll()
                 .requestMatchers("/t-exercise/allboard").permitAll()
                 .requestMatchers("/t-exercise/selectboard/**").permitAll()
+                .requestMatchers("/api/find/**").permitAll()
                 .anyRequest().authenticated()//인증이 되어야 한다는 이야기이다.
                 //.anonymous() : 인증되지 않은 사용자도 접근할 수 있다.
                 // JWT 인증/인가를 사용하기 위한 설정
@@ -76,10 +80,10 @@ public class WebSecurityConfig {
 //        http.exceptionHandling().accessDeniedPage("/api/user/forbidden");
         return http.build();
     }
-//    @Override
-//    public void addCoreMappings(CorsRegistry registry){
-//        registry.addMapping("/**")
-//                .allowedMethods("GET","POST","PUT","DELETE","OPTIONS", "HEAD");
-//
-//    }
+    @Override
+    public void addCorsMappings(CorsRegistry registry){
+        registry.addMapping("/**")
+                .allowedMethods("GET","POST","PUT","DELETE","OPTIONS", "HEAD")
+                .exposedHeaders("Authorization");
+    }
 }

--- a/src/main/java/com/team/final8teamproject/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/team/final8teamproject/security/jwt/JwtAuthFilter.java
@@ -6,12 +6,10 @@ import com.team.final8teamproject.security.redis.RedisUtil;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -40,6 +38,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             if(refreshToken){
                 throw new IllegalArgumentException("Please Login again.");
             }
+            /**
+             여기서 관리자인지 유저인지 확인한다음에..
+             setAuthentication을 해줘야한다...
+             어떤게 권한을 확인하고 보내줄것인가? 답없는데..??
+             합쳐서 해야하나? 나눠서 해야하나??
+             한 데이터베이스에 넣어두지 않을탠데..
+             */
             Claims info = jwtUtil.getUserInfoFromToken(token);
             setAuthentication(info.getSubject());
         }
@@ -53,7 +58,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     public void setAuthentication(String username) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         //jwtUtil에서  username에 알맞은 User객체를 가져와서 Authentication에 넣어준다.
-        Authentication authentication = jwtUtil.createAuthentication(username);
+        Authentication authentication = jwtUtil.createUserAuthentication(username);
+
         //그리고 빈 컨텍스트에 가져온 데이터(User객체와, username) authentication변수를 넣어주고
         context.setAuthentication(authentication);
         //누가 인증하였는지에 대한 정보들을 저장한다.

--- a/src/main/java/com/team/final8teamproject/security/jwt/JwtUtil.java
+++ b/src/main/java/com/team/final8teamproject/security/jwt/JwtUtil.java
@@ -1,6 +1,8 @@
 package com.team.final8teamproject.security.jwt;
 
 
+import com.team.final8teamproject.manager.entity.ManagerRoleEnum;
+import com.team.final8teamproject.security.mamagerservice.*;
 import com.team.final8teamproject.user.dto.LoginResponseDto;
 import com.team.final8teamproject.user.entity.UserRoleEnum;
 import com.team.final8teamproject.security.userservice.UserDetailsServiceImpl;
@@ -33,6 +35,8 @@ public class JwtUtil {
     private static final long ACCESS_TOKEN_TIME = 60 * 30 * 1000L;            // 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 2 * 24 * 60 * 60 * 1000L; //2일
     private final UserDetailsServiceImpl userDetailsService;
+    private final ManagerDetailsServiceImpl managerDetailsService;
+    private final GeneralManagerDetailsServiceImpl generalManagerDetailsService;
     @Value("${jwt.secret.key}")
     private String secretKey;
     private Key key;
@@ -54,19 +58,39 @@ public class JwtUtil {
         return null;
     }
 
+    /**
+     *  일반유저, 오너유저, 총관리자, 관리자 토큰 생성 메소드 부분
+     */
+
     // 토큰 생성
-    //유저정보를 가지고 AccessToken, RefreshToken 을 생성하는 메서드
-    public LoginResponseDto createToken(String username, UserRoleEnum role) {
+    //유저(일반 사업자)정보를 가지고 AccessToken, RefreshToken 을 반환해주는 메서드
+    public LoginResponseDto createUserToken(String username, UserRoleEnum role) {
         Date date = new Date();
         //권한 가져오기
         // BEARER : 인증 타입중 하나로 JWT 또는 OAuth에 대한 토큰을 사용 (RFC 6750 문서 확인)
-        String accessToken = BEARER_PREFIX + Jwts.builder()
-                        .setSubject(username) // 토큰 용도
-                        .claim(AUTHORIZATION_KEY, role) // payload에 들어갈 정보 조각들
-                        .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME)) // 만료시간 설정
-                        .setIssuedAt(date) // 토큰 발행일
-                        .signWith(key, signatureAlgorithm) // key변수 값과 해당 알고리즘으로 sign
-                        .compact(); // 토큰 생성
+        return getLoginResponseDto(Jwts.builder()
+                .setSubject(username) // 토큰 용도
+                .claim(AUTHORIZATION_KEY, role), date);
+    }
+
+
+    // 총관리자, 관리자 가지고 AccessToken, RefreshToken 을 반환해주는 메서드
+    public LoginResponseDto createManagerToken(String general, ManagerRoleEnum role) {
+        Date date = new Date();
+        //권한 가져오기
+        // BEARER : 인증 타입중 하나로 JWT 또는 OAuth에 대한 토큰을 사용 (RFC 6750 문서 확인)
+        return getLoginResponseDto(Jwts.builder()
+                .setSubject(general) // 토큰 용도
+                .claim(AUTHORIZATION_KEY, role), date);
+    }
+
+    //토큰(AccessToken, RefreshToken) 생성 메서드
+    private LoginResponseDto getLoginResponseDto(JwtBuilder general, Date date) {
+        String accessToken = BEARER_PREFIX + general // payload에 들어갈 정보 조각들
+                .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME)) // 만료시간 설정
+                .setIssuedAt(date) // 토큰 발행일
+                .signWith(key, signatureAlgorithm) // key변수 값과 해당 알고리즘으로 sign
+                .compact(); // 토큰 생성
 
         String refreshToken = Jwts.builder()
                 .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
@@ -80,6 +104,44 @@ public class JwtUtil {
                 .refreshTokenExpirationTime(REFRESH_TOKEN_EXPIRE_TIME)
                 .build();
     }
+
+
+    /**
+     *  일반유저, 오너유저, 총관리자, 관리자 인증 객체 생성 메소드 부분
+     */
+    // 일반 유저 인증 객체 생성
+    public Authentication createUserAuthentication(String username) {
+        //
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+    //오너 유저 인증 객체 생성
+
+    //총 관리자 인증 객체 생성
+    public Authentication createGeneralManagerAuthentication(String general) {
+        //
+        GeneralManagerDetails generalManager = generalManagerDetailsService.loadManagerByGeneralName(general);
+
+        return new UsernamePasswordAuthenticationToken(generalManager, null, generalManager.getAuthorities());
+    }
+
+    //관리자 인증 객체 생성
+    public Authentication createManagerAuthentication(String manager) {
+        //
+        ManagerDetails managerDetails = managerDetailsService.loadManagerByManagerName(manager);
+
+        return new UsernamePasswordAuthenticationToken(managerDetails, null, managerDetails.getAuthorities());
+    }
+
+
+    /**
+     *  -----------------------------------------------
+     *
+     *     Header에서 가져온 토큰 검증하는 메소드
+     *
+     *  -----------------------------------------------
+     */
 
     // 토큰 검증
     // Header에서 토큰 가져오기
@@ -107,14 +169,6 @@ public class JwtUtil {
         return false;
     }
 
-    // 인증 객체 생성
-    public Authentication createAuthentication(String username) {
-        //
-        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-
-    }
     public Claims getUserInfoFromToken(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetails.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetails.java
@@ -12,16 +12,15 @@ public interface GeneralManagerDetails extends Serializable {
      */
     Collection<? extends GrantedAuthority> getAuthorities();
 
-    /**
-     * Returns the password used to authenticate the user.
-     * @return the password
-     */
+    String getGeneralName();
+
     String getPassword();
 
-    /**
-     * Returns the username used to authenticate the user. Cannot return
-     * <code>null</code>.
-     * @return the username (never <code>null</code>)
-     */
-    String getGeneralManager();
+    boolean isAccountNonExpired();
+
+    boolean isAccountNonLocked();
+
+    boolean isCredentialsNonExpired();
+
+    boolean isEnabled();
 }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetailsImpl.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetailsImpl.java
@@ -1,4 +1,61 @@
 package com.team.final8teamproject.security.mamagerservice;
 
-public class GeneralManagerDetailsImpl {
+import com.team.final8teamproject.manager.entity.GeneralManager;
+import com.team.final8teamproject.manager.entity.ManagerRoleEnum;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class GeneralManagerDetailsImpl implements GeneralManagerDetails{
+
+    private final GeneralManager generalManager;
+    private final String generalName;
+    public GeneralManagerDetailsImpl(GeneralManager generalManager, String generalName) {
+        this.generalManager = generalManager;
+        this.generalName = generalName;
+    }
+    public GeneralManager getGeneralManager() {
+        return generalManager;
+    }
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ManagerRoleEnum role = generalManager.getRole();
+        String authority = role.getAuthority();
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+    @Override
+    public String getGeneralName() {
+        return this.generalName;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
 }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetailsService.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetailsService.java
@@ -1,4 +1,8 @@
 package com.team.final8teamproject.security.mamagerservice;
 
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
 public interface GeneralManagerDetailsService {
+    GeneralManagerDetails loadManagerByGeneralName(String generalName) throws UsernameNotFoundException;
 }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetailsServiceImpl.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/GeneralManagerDetailsServiceImpl.java
@@ -1,4 +1,24 @@
 package com.team.final8teamproject.security.mamagerservice;
 
-public class GeneralManagerDetailsServiceImpl {
+import com.team.final8teamproject.manager.entity.GeneralManager;
+import com.team.final8teamproject.manager.repository.GeneralManagerRepository;
+import com.team.final8teamproject.security.userservice.UserDetailsImpl;
+import com.team.final8teamproject.user.entity.User;
+import com.team.final8teamproject.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GeneralManagerDetailsServiceImpl implements  GeneralManagerDetailsService {
+    private final GeneralManagerRepository generalManagerRepository;
+    @Override
+    public GeneralManagerDetails loadManagerByGeneralName(String generalName) throws UsernameNotFoundException {
+            GeneralManager manager = generalManagerRepository.findByGeneralName(generalName).orElseThrow(
+                    () -> new UsernameNotFoundException("Manager Not Found"));
+
+        return new GeneralManagerDetailsImpl(manager, manager.getGeneralName());
+    }
 }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetails.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetails.java
@@ -6,23 +6,21 @@ import java.io.Serializable;
 import java.util.Collection;
 
 public interface ManagerDetails extends Serializable {
-
     /**
      * Returns the authorities granted to the user. Cannot return <code>null</code>.
      * @return the authorities, sorted by natural key (never <code>null</code>)
      */
     Collection<? extends GrantedAuthority> getAuthorities();
 
-    /**
-     * Returns the password used to authenticate the user.
-     * @return the password
-     */
+    String getManagerName();
+
     String getPassword();
 
-    /**
-     * Returns the username used to authenticate the user. Cannot return
-     * <code>null</code>.
-     * @return the username (never <code>null</code>)
-     */
-    String getManager();
+    boolean isAccountNonExpired();
+
+    boolean isAccountNonLocked();
+
+    boolean isCredentialsNonExpired();
+
+    boolean isEnabled();
 }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetailsImpl.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetailsImpl.java
@@ -1,4 +1,65 @@
 package com.team.final8teamproject.security.mamagerservice;
 
-public class ManagerDetailsImpl {
+import com.team.final8teamproject.manager.entity.GeneralManager;
+import com.team.final8teamproject.manager.entity.Manager;
+import com.team.final8teamproject.manager.entity.ManagerRoleEnum;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ManagerDetailsImpl implements  ManagerDetails{
+
+
+    private final Manager manager;
+    private final String managerName;
+
+
+    public ManagerDetailsImpl(Manager manager, String managerName) {
+        this.manager = manager;
+        this.managerName = managerName;
+    }
+    public Manager getManager() {
+        return manager;
+    }
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ManagerRoleEnum role = manager.getRole();
+        String authority = role.getAuthority();
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+        return authorities;
+    }
+
+    @Override
+    public String getManagerName() {
+        return managerName;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
 }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetailsService.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetailsService.java
@@ -5,5 +5,5 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 public interface ManagerDetailsService {
 
-    ManagerDetails loadManagerByManager(String username) throws UsernameNotFoundException;
+    ManagerDetails loadManagerByManagerName(String managerName) throws UsernameNotFoundException;
 }

--- a/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetailsServiceImpl.java
+++ b/src/main/java/com/team/final8teamproject/security/mamagerservice/ManagerDetailsServiceImpl.java
@@ -1,4 +1,21 @@
 package com.team.final8teamproject.security.mamagerservice;
 
-public class ManagerDetailsServiceImpl {
+import com.team.final8teamproject.manager.entity.Manager;
+import com.team.final8teamproject.manager.repository.ManagerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerDetailsServiceImpl implements  ManagerDetailsService{
+
+    private final ManagerRepository managerRepository;
+    @Override
+    public ManagerDetails loadManagerByManagerName(String managerName) throws UsernameNotFoundException {
+        Manager manager = managerRepository.findByManagerName(managerName).orElseThrow(
+                () -> new UsernameNotFoundException("사용자를 없습니다.")
+        );
+        return new ManagerDetailsImpl(manager, manager.getManagerName());
+    }
 }

--- a/src/main/java/com/team/final8teamproject/security/userservice/EmailServiceImpl.java
+++ b/src/main/java/com/team/final8teamproject/security/userservice/EmailServiceImpl.java
@@ -3,7 +3,7 @@ package com.team.final8teamproject.security.userservice;
 import jakarta.mail.Message;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -11,11 +11,9 @@ import org.springframework.stereotype.Service;
 import java.util.Random;
 
 @Service
+@RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService{
-
-    @Autowired
-    JavaMailSender emailSender;
-
+    private final JavaMailSender emailSender;
     public static String ePw;
 
     private MimeMessage createMessage(String to)throws Exception{

--- a/src/main/java/com/team/final8teamproject/security/userservice/UserDetailsImpl.java
+++ b/src/main/java/com/team/final8teamproject/security/userservice/UserDetailsImpl.java
@@ -1,6 +1,6 @@
 package com.team.final8teamproject.security.userservice;
 
-import com.team.final8teamproject.user.entity.User;
+import com.team.final8teamproject.base.entity.BaseEntity;
 import com.team.final8teamproject.user.entity.UserRoleEnum;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -10,21 +10,21 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class UserDetailsImpl implements UserDetails {
-    private final User user;
+    private final BaseEntity base;
     private final String username;
 
-    public UserDetailsImpl(User user, String username) {
-        this.user = user;
+    public UserDetailsImpl(BaseEntity base, String username) {
+        this.base = base;
         this.username = username;
     }
 
-    public User getUser() {
-        return user;
+    public BaseEntity getBase() {
+        return base;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        UserRoleEnum role = user.getRole();
+        UserRoleEnum role = base.getRole();
         String authority = role.getAuthority();
 
         SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);

--- a/src/main/java/com/team/final8teamproject/security/userservice/UserDetailsServiceImpl.java
+++ b/src/main/java/com/team/final8teamproject/security/userservice/UserDetailsServiceImpl.java
@@ -1,7 +1,7 @@
 package com.team.final8teamproject.security.userservice;
 
-import com.team.final8teamproject.user.entity.User;
-import com.team.final8teamproject.user.repository.UserRepository;
+import com.team.final8teamproject.base.entity.BaseEntity;
+import com.team.final8teamproject.base.repository.BaseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -11,13 +11,18 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserDetailsServiceImpl implements UserDetailsService {
-    private final UserRepository userRepository;
+    private final BaseRepository baseRepository;
 
+//    @Override
+//    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+//        User user = userRepository.findByUsername(username)
+//                .orElseThrow(() -> new UsernameNotFoundException("User Not Found "));
+//        return new UserDetailsImpl(user, user.getUsername());
+//    }
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
+        BaseEntity base = baseRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User Not Found "));
-        return new UserDetailsImpl(user, user.getUsername());
+        return new UserDetailsImpl(base, base.getUsername());
     }
-
 }

--- a/src/main/java/com/team/final8teamproject/share/exception/ExceptionAdviceHandler.java
+++ b/src/main/java/com/team/final8teamproject/share/exception/ExceptionAdviceHandler.java
@@ -1,5 +1,8 @@
 package com.team.final8teamproject.share.exception;
 
+import com.team.final8teamproject.share.exception.dto.ApiExceptionDTO;
+import com.team.final8teamproject.share.exception.dto.ErrorDTO;
+import io.jsonwebtoken.security.SecurityException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -7,6 +10,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
 
 @Slf4j
 @RestControllerAdvice
@@ -21,16 +26,28 @@ public class ExceptionAdviceHandler {
                 HttpStatus.valueOf(customException.getExceptionStatus().getStatusCode()));
     }
 
-
-        @ExceptionHandler({IllegalArgumentException.class})
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    protected ResponseEntity handleIllegalArgumentException(IllegalArgumentException e) {
-        ApiExceptionDTO apiExceptionDto = new ApiExceptionDTO(e.getMessage(), HttpStatus.BAD_REQUEST);
+//    @ExceptionHandler()
+//    @ResponseStatus()
+//    public ApiExceptionDTO SizeException(){
+//        log.warn(e.getMessage());
+//        return new ApiExceptionDTO();
+//    }
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    //상태코드를 400으로 집어넣어줌
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ApiExceptionDTO handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn(e.getMessage());
-        return new ResponseEntity(apiExceptionDto, HttpStatus.BAD_REQUEST);
+        return new ApiExceptionDTO(e.getMessage(), 404);
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(SecurityException.class)
+    public ApiExceptionDTO SecurityExceptionExceptionHandling(SecurityException exception) {
+        log.warn(exception.getMessage());
+        return new ApiExceptionDTO(exception.getMessage(),403);
     }
     @ExceptionHandler({NullPointerException.class})
-    protected ResponseEntity handleNullPointerException(Exception e) {
+    protected ResponseEntity handleNullPointerException(java.lang.Exception e) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 //    @ExceptionHandler({NullPointerException.class})
@@ -42,9 +59,15 @@ public class ExceptionAdviceHandler {
 //        return new ResponseEntity(apiExceptionDto, HttpStatus.BAD_REQUEST);
 //    }
 
+    @ExceptionHandler({NoSuchElementException.class})
+    protected ApiExceptionDTO handleMtehodNotFindExcpetion(NoSuchElementException e){
+        log.warn(e.getMessage());
+        return new ApiExceptionDTO(e.getMessage(), 403);
+    }
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
     protected ResponseEntity handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn(e.getMessage());
         return new ResponseEntity<>(e.getBindingResult().getFieldError().getDefaultMessage(), HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/team/final8teamproject/share/exception/ExceptionStatus.java
+++ b/src/main/java/com/team/final8teamproject/share/exception/ExceptionStatus.java
@@ -18,16 +18,14 @@ public enum ExceptionStatus {
     WRONG_ADMINTOKEN(400, "잘못된 관리자 비밀번호 입니다."),
     ACCESS_DENINED(500, "접근 권한이 없습니다."),
     AUTHENTICATION(500, "인증 실패"),
-    BOARD_NOT_EXIST(404, "해당하는 아이디의 게시물이 없습니다."),
-    COMMENT_NOT_EXIST(404, "해당하는 아이디의 댓글이 없습니다."),
-    COMMENT_REPLY_NOT_EXIST(404, "해당하는 아이디의 대댓글이 없습니다."),
+    BOARD_NOT_EXIST(404, "게시물이 삭제되어 존재하지 않습니다."),
+    COMMENT_NOT_EXIST(404, "해당 댓글이 삭제되어 존재 하지 않습니다."),
+    COMMENT_REPLY_NOT_EXIST(404, "해당하는 댓글이 삭제되어 존재 하지 않습니다."),
     REQUEST_NOT_EXIST(404,"해당하는 요청이 존재하지 않습니다."),
     WRONG_SELLER_ID_T0_BOARD(403,"다른 판매자의 게시물에는 접근 할 수 없습니다."),
     WRONG_USER_T0_COMMENT(403,"다른 유저의 댓글에는 접근 할 수 없습니다."),
     WRONG_USER_T0_COMMENT_REPLY(403,"다른 유저의 대댓글에는 접근 할 수 없습니다."),
     WRONG_SELLER_ID_TO_USER_REQUEST(403,"다른 판매자의 요청목록에는 접근 할 수 없습니다.");
-
-
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/com/team/final8teamproject/share/exception/dto/ApiExceptionDTO.java
+++ b/src/main/java/com/team/final8teamproject/share/exception/dto/ApiExceptionDTO.java
@@ -1,4 +1,4 @@
-package com.team.final8teamproject.share.exception;
+package com.team.final8teamproject.share.exception.dto;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -8,10 +8,10 @@ import org.springframework.http.HttpStatus;
 @Setter
 public class ApiExceptionDTO {
     private String errorMessage;
-    private HttpStatus httpStatus;
-    public  ApiExceptionDTO(String errorMessage, HttpStatus httpStatus){
+    private int Status;
+    public  ApiExceptionDTO(String errorMessage, int Status){
         this.errorMessage = errorMessage;
-        this.httpStatus = httpStatus;
+        this.Status = Status;
     }
 
 }

--- a/src/main/java/com/team/final8teamproject/share/exception/dto/ErrorDTO.java
+++ b/src/main/java/com/team/final8teamproject/share/exception/dto/ErrorDTO.java
@@ -1,4 +1,4 @@
-package com.team.final8teamproject.share.exception;
+package com.team.final8teamproject.share.exception.dto;
 
 import lombok.Data;
 import lombok.Getter;

--- a/src/main/java/com/team/final8teamproject/user/controller/ProfileController.java
+++ b/src/main/java/com/team/final8teamproject/user/controller/ProfileController.java
@@ -3,6 +3,7 @@ package com.team.final8teamproject.user.controller;
 import com.team.final8teamproject.security.userservice.UserDetailsImpl;
 import com.team.final8teamproject.user.dto.ProfileModifyRequestDto;
 import com.team.final8teamproject.user.dto.ProfileResponseDto;
+import com.team.final8teamproject.user.entity.User;
 import com.team.final8teamproject.user.service.ProfileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +19,15 @@ public class ProfileController {
     //1. 프로필 조회
     @GetMapping()
     public ProfileResponseDto getProfile(@Valid @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        return profileService.getProfile(userDetailsImpl.getUser());
+
+        return profileService.getProfile((User) userDetailsImpl.getBase());
     }
 
     //2. 프로필 수정
     @PostMapping()
     public void modifyProfile(@Valid @RequestBody ProfileModifyRequestDto profileModifyRequestDto
             , @AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        profileService.modifyProfile(profileModifyRequestDto, userDetailsImpl.getUser());
+        profileService.modifyProfile(profileModifyRequestDto, (User) userDetailsImpl.getBase());
     }
 
 }

--- a/src/main/java/com/team/final8teamproject/user/controller/UserController.java
+++ b/src/main/java/com/team/final8teamproject/user/controller/UserController.java
@@ -47,13 +47,26 @@ public class UserController {
     public MessageResponseDto logout(@AuthenticationPrincipal UserDetailsImpl userDetails
     , HttpServletRequest request){
         String accessToken = jwtUtil.resolveToken(request);
+
         return new MessageResponseDto(userService.logout(accessToken, userDetails.getUsername()));
     }
 
     //4. 이메일 인증
-    @PostMapping("/emailConfirm")
+    @PostMapping("/emailcconfirm")
     public String emailConfirm(@RequestParam String email) throws Exception {
         return emailService.sendSimpleMessage(email);
     }
-
+    //파일서비스란 인터페이스를 만들어서 이것을 이용하여 저장하게 해놓으면
+    //나중에 할수있다.
+    //http표준 요청상에는 get은 body를 사용하면 안된다. param을 사용해야한다.
+    //5.Id찾기
+    @GetMapping("/find/username")
+    public FindByResponseDto getfindByUsername(@RequestParam("email") String email){
+        return userService.findByUsername(email);
+    }
+    //6.Password찾기
+    @PostMapping("/find/password")
+    public FindByResponseDto findPassword(@RequestBody FindPasswordRequestDto responseDto) {
+        return userService.userFindPassword(responseDto);
+    }
 }

--- a/src/main/java/com/team/final8teamproject/user/dto/FindByResponseDto.java
+++ b/src/main/java/com/team/final8teamproject/user/dto/FindByResponseDto.java
@@ -1,0 +1,11 @@
+package com.team.final8teamproject.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FindByResponseDto {
+    private String username;
+    public FindByResponseDto(String username){
+        this.username = username;
+    }
+}

--- a/src/main/java/com/team/final8teamproject/user/dto/FindPasswordRequestDto.java
+++ b/src/main/java/com/team/final8teamproject/user/dto/FindPasswordRequestDto.java
@@ -1,0 +1,15 @@
+package com.team.final8teamproject.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FindPasswordRequestDto {
+    private String username;
+    private String email;
+
+    private String password;
+
+    public void setPassword(String password){
+        this.password = password;
+    }
+}

--- a/src/main/java/com/team/final8teamproject/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/team/final8teamproject/user/dto/SignupRequestDto.java
@@ -3,6 +3,7 @@ package com.team.final8teamproject.user.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,6 +31,7 @@ public class SignupRequestDto {
     private String image;
 
     @NotBlank
+//    @Size(min=2,max=4, message = "사용자이름은 2~4글자여야 합니다.")
     private String nickName;
 
     @NotBlank

--- a/src/main/java/com/team/final8teamproject/user/entity/KaKao.java
+++ b/src/main/java/com/team/final8teamproject/user/entity/KaKao.java
@@ -1,0 +1,21 @@
+package com.team.final8teamproject.user.entity;
+
+import com.team.final8teamproject.base.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity(name = "KaKao")
+@DiscriminatorValue(value = "KaKao")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KaKao extends BaseEntity {
+    @Column(nullable = false)
+    private Long id;
+    private String profileImage;
+    private String nickName;
+    private Long experience = 0L;
+}

--- a/src/main/java/com/team/final8teamproject/user/entity/User.java
+++ b/src/main/java/com/team/final8teamproject/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.team.final8teamproject.user.entity;
 
+import com.team.final8teamproject.base.entity.BaseEntity;
 import com.team.final8teamproject.user.dto.ProfileModifyRequestDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,37 +9,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@DiscriminatorValue(value = "Users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "users")
-public class User extends Timestamped {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "User_ID")
-    private Long id;
-
-    @Column(nullable = false, unique = true)
-    private String username;
-
-    @Column(nullable = false)
-    private String password;
-
+public class User extends BaseEntity {
     private String profileImage;
-
     @Column(nullable = false)
     private String nickName;
-
-    @Column(nullable = false)
-    @Enumerated(value = EnumType.STRING)
-    private UserRoleEnum role;
-
     @Column(nullable = false)
     private String phoneNumber;
-
-    @Column(nullable = false)
-    private String email;
-
-
     @Column(nullable = false)
     private Long experience;
 
@@ -46,13 +25,10 @@ public class User extends Timestamped {
     public User(String username, String password, UserRoleEnum role,
                 String nickName, String phoneNumber, String email,
                 Long experience){
-        this.username =username;
-        this.password = password;
+        super(username, password, email, role);
         this.nickName = nickName;
         this.phoneNumber = phoneNumber;
-        this.email = email;
         this.experience = experience;
-        this.role = role;
     }
 
     public void changeProfile(ProfileModifyRequestDto profileModifyRequestDto) {
@@ -61,11 +37,4 @@ public class User extends Timestamped {
         this.phoneNumber = profileModifyRequestDto.getPhoneNumber();
     }
 
-    public boolean isUserId(Long userid) {
-        return this.id.equals(userid);
-    }
-
-    public String getWriterName() {
-        return this.username;
-    }
 }

--- a/src/main/java/com/team/final8teamproject/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/team/final8teamproject/user/entity/UserRoleEnum.java
@@ -1,9 +1,13 @@
 package com.team.final8teamproject.user.entity;
 
+import com.team.final8teamproject.manager.entity.ManagerRoleEnum;
+
 public enum UserRoleEnum {
     OWNER(Authority.OWNER),  // 사업자 권한
     MEMBER(Authority.MEMBER),  // 회원 권한
-    MANAGER(Authority.MANAGER);  // 관리자 권한
+    GENERAL_MANAGER(Authority.GENERAL_MANAGER),  // 총관리자 권한
+    MANAGER(Authority.MANAGER),
+    WAIT(Authority.WAIT);  // 관리자 권한;  // 관리자 권한
 
     private final String authority;
 
@@ -18,7 +22,9 @@ public enum UserRoleEnum {
     public static class Authority {
         public static final String OWNER  = "ROLE_OWNER";
         public static final String MEMBER = "ROLE_MEMBER";
+        public static final String GENERAL_MANAGER = "ROLE_GENERAL_MANAGER";
         public static final String MANAGER = "ROLE_MANAGER";
+        public static final String WAIT = "ROLE_WAIT";
     }
 
 }

--- a/src/main/java/com/team/final8teamproject/user/repository/UserRepository.java
+++ b/src/main/java/com/team/final8teamproject/user/repository/UserRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "Size.joinUser.nickName",
+      "type": "java.lang.String",
+      "description": "Description for Size.joinUser.nickName."
+  }
+] }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 
 spring.data.redis.host=localhost
-spring.data.redis.port=6379
-
+spring.data.redis.port=6379 
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.generate-ddl=true
 

--- a/src/test/java/com/team/final8teamproject/backjoon/TestBack.java
+++ b/src/test/java/com/team/final8teamproject/backjoon/TestBack.java
@@ -2,6 +2,9 @@ package com.team.final8teamproject.backjoon;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 class TestBack {
@@ -33,5 +36,15 @@ class TestBack {
         //then
         assertEquals(result1, 10);
         assertEquals(result2, 28);
+    }
+
+    @Test
+    public void BaekJoonLine(){
+        //given
+
+        //when
+
+        //then
+
     }
 }


### PR DESCRIPTION
BaseEntity에 관리자 권한도 같이 통합하여 관리
Manger에서 BaseEntity상속 UserRoleEnum.java 관리자 속성 추가
계정통합검색을 위하여 BaseEntity.java를 기준으로 상속받아 User, Owner, KaKao생성
UserService.java에 유저 아이디 찾기/패스워드찾기 추가
UserController.java에 유저 아디이찾기/패스워드 찾기 주소및 UserService.java 호출하여 반환추가